### PR TITLE
ptr::invalid is not the same as a cast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,8 +363,8 @@
 
 /// Creates an invalid pointer with the given address.
 ///
-/// This is *currently* equivalent to `addr as *const T` but it expresses the intended semantic
-/// more clearly, and may become important under future memory models.
+/// This is different from `addr as *const T`, which creates a pointer that picks up a previously
+/// exposed provenance. See [`from_exposed_addr`] for more details on that operation.
 ///
 /// The module's top-level documentation discusses the precise meaning of an "invalid"
 /// pointer but essentially this expresses that the pointer is not associated
@@ -372,7 +372,7 @@
 ///
 /// This pointer will have no provenance associated with it and is therefore
 /// UB to read/write/offset. This mostly exists to facilitate things
-/// like ptr::null and NonNull::dangling which make invalid pointers.
+/// like `ptr::null` and `NonNull::dangling` which make invalid pointers.
 ///
 /// (Standard "Zero-Sized-Types get to cheat and lie" caveats apply, although it
 /// may be desirable to give them their own API just to make that 100% clear.)
@@ -396,8 +396,8 @@ pub const fn invalid<T>(addr: usize) -> *const T {
 
 /// Creates an invalid mutable pointer with the given address.
 ///
-/// This is *currently* equivalent to `addr as *mut T` but it expresses the intended semantic
-/// more clearly, and may become important under future memory models.
+/// This is different from `addr as *mut T`, which creates a pointer that picks up a previously
+/// exposed provenance. See [`from_exposed_addr_mut`] for more details on that operation.
 ///
 /// The module's top-level documentation discusses the precise meaning of an "invalid"
 /// pointer but essentially this expresses that the pointer is not associated
@@ -405,7 +405,7 @@ pub const fn invalid<T>(addr: usize) -> *const T {
 ///
 /// This pointer will have no provenance associated with it and is therefore
 /// UB to read/write/offset. This mostly exists to facilitate things
-/// like ptr::null and NonNull::dangling which make invalid pointers.
+/// like `ptr::null` and `NonNull::dangling` which make invalid pointers.
 ///
 /// (Standard "Zero-Sized-Types get to cheat and lie" caveats apply, although it
 /// may be desirable to give them their own API just to make that 100% clear.)


### PR DESCRIPTION
Syncs with https://github.com/rust-lang/rust/pull/97482