### PR TITLE
use transmute for ptr.addr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,7 +604,9 @@ impl<T> Strict for *mut T {
         T: Sized,
     {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler intrinsic.
-        self as usize
+        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the
+        // provenance).
+        unsafe { core::mem::transmute(self) }
     }
 
     #[must_use]
@@ -658,7 +660,9 @@ impl<T> Strict for *const T {
         T: Sized,
     {
         // FIXME(strict_provenance_magic): I am magic and should be a compiler intrinsic.
-        self as usize
+        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the
+        // provenance).
+        unsafe { core::mem::transmute(self) }
     }
 
     #[must_use]


### PR DESCRIPTION
Syncs with https://github.com/rust-lang/rust/pull/97710

Once https://github.com/rust-lang/miri/issues/2133 is complete, this then correctly implements the distinction between `addr` and `expose_addr`, as well as between `invalid` and `from_exposed_addr`. Misuses of these APIs are detected by Miri, and ptr-int-ptr roundtrips only work if you use `expose_addr` *and* `from_exposed_addr`. :)